### PR TITLE
Fix signed request data.

### DIFF
--- a/com.jenwachter.PawExtensions.AkamaiOpenEdgeGridAuthorization/AkamaiOpenEdgeGridAuthorization.js
+++ b/com.jenwachter.PawExtensions.AkamaiOpenEdgeGridAuthorization/AkamaiOpenEdgeGridAuthorization.js
@@ -77,7 +77,8 @@ function parseuri(str) {
 
 function getSignature(key, request, authorization) {
   var parts = parseuri(request.url);
-  return signHmac256(key, request.method + '\thttps\t' + parts.host + '\t' + parts.path + '\t\t' + hash256(request.body) + '\t' + authorization);
+  var input = request.method + '\thttps\t' + parts.host + '\t' + parts.path + '\t\t\t' + authorization;
+  return signHmac256(key, input);
 }
 
 var AkamaiOpenEdgeGridAuthorization = function () {


### PR DESCRIPTION
I had to carefully parse out how Akamai's libraries differed from their
documentation, to figure out why this Paw extension wasn't working.
Turns out the hashed data partway through the request message to be
signed, wasn't necessary after all. With this change, the Paw extension
now works for me.