### PR TITLE
Added query string to signature

### DIFF
--- a/com.jenwachter.PawExtensions.AkamaiOpenEdgeGridAuthorization/AkamaiOpenEdgeGridAuthorization.js
+++ b/com.jenwachter.PawExtensions.AkamaiOpenEdgeGridAuthorization/AkamaiOpenEdgeGridAuthorization.js
@@ -79,6 +79,11 @@ function getSignature(key, request, authorization) {
   var parts = parseuri(request.url);
 
   var value = request.method + '\thttps\t' + parts.host + '\t' + parts.path + '\t\t';
+  
+  if(parts.query) {
+    value = request.method + '\thttps\t' + parts.host + '\t' + parts.path + '?' + parts.query +  '\t\t';
+  }
+  
   if (request.method === 'POST') {
     value += hash256(request.body);
   }


### PR DESCRIPTION
If URL contains a query string, this should be added to the path according to https://developer.akamai.com/legacy/introduction/Client_Auth.html

For example for /storage/v1/storage-groups?cpcodeId=123456